### PR TITLE
Configure External Slurm

### DIFF
--- a/system-config/packages.yaml
+++ b/system-config/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  slurm:
+    externals:
+    - spec: slurm@20.11
+      prefix: /usr
+    buildable: False
   openssh:
     externals:
     - spec: openssh@7.4p1

--- a/system-config/packages.yaml
+++ b/system-config/packages.yaml
@@ -1,7 +1,7 @@
 packages:
   slurm:
     externals:
-    - spec: slurm@20.11
+    - spec: slurm@20-11-8-1 sysconfdir=/etc/slurm
       prefix: /usr
     buildable: False
   openssh:


### PR DESCRIPTION
We need to configure spack to use our own slurm. Buildable should be false, since there is no reason for users to be installing their own slurm, and it's likely to lead to user confusion. see https://github.com/ArjunaCluster/ArjunaUsers/issues/53

