### PR TITLE
Add external openmpi spec, and default to using slurm

### DIFF
--- a/system-config/packages.yaml
+++ b/system-config/packages.yaml
@@ -4,6 +4,11 @@ packages:
     - spec: openssh@7.4p1
       prefix: /usr
     buildable: False
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.1 schedulers=slurm +thread_multiple ~cuda +singularity %gcc@4.8.5
+    buildable: True
+    variants: "schedulers=slurm"
   python:
     variants: "~pythoncmd"
   cmake:

--- a/system-config/packages.yaml
+++ b/system-config/packages.yaml
@@ -7,6 +7,7 @@ packages:
   openmpi:
     externals:
     - spec: openmpi@4.1.1 schedulers=slurm +thread_multiple ~cuda +singularity %gcc@4.8.5
+    prefix: /usr/local
     buildable: True
     variants: "schedulers=slurm"
   python:


### PR DESCRIPTION
Not 100% certain on the spec (Other flags may be flipped) but confident
these flags are flipped

Set the default varient to use slurm (As we use slurm) should wait for
#1 (For external slurm package)

## Buildable Flag

As this was build with gcc@4.8.5 setting `buildable: False` would limit the compiler to gcc%4.8.5 for most packages. Additionally the lack of cuda support isn't ideal. 

This does mean that most users will end up using the spack openmpi

## Deploy Actions
Pull Updates
Rebuild common environment to apply added openmpi variants / updated system openmpi
